### PR TITLE
Compilation and test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 .project
 .*~
 .*.swp
+/*.o
+/*.obj
+/blib
+/pm_to_blib
+/XS.bs
+/Grpc.c
+/MYMETA.*
+/Makefile*

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,6 +2,7 @@ use 5.008005;
 use ExtUtils::MakeMaker;
 
 use Getopt::Long;
+use Devel::CheckLib;
 
 # perl Makefile.PL -d to enable -g flag for gdb.
 Getopt::Long::Configure('pass_through');
@@ -11,20 +12,41 @@ GetOptions(
 )
     or die "Error in command line arguments\n";
 
-my ($EXTRA_CPPFLAGS, $EXTRA_LDFLAGS);
+my ($EXTRA_INCFLAGS, $EXTRA_DEFINES, $EXTRA_LDFLAGS, %CHECKLIB_ARGS);
 if ($GRPC_PREFIX) {
-    $EXTRA_CPPFLAGS = "-I$GRPC_PREFIX/include";
+    $EXTRA_INCFLAGS = "-I$GRPC_PREFIX/include";
     $EXTRA_LDFLAGS = "-L$GRPC_PREFIX/lib";
+    $EXTRA_DEFINES = '';
+    %CHECKLIB_ARGS = (
+        header      => 'grpc/grpc.h',
+        INC         => $EXTRA_INCFLAGS,
+        LIBS        => "$EXTRA_LDFLAGS -lgrpc",
+    );
+} else {
+    $EXTRA_INCFLAGS = $EXTRA_DEFINES = $EXTRA_LDFLAGS = '';
+    %CHECKLIB_ARGS = (
+        LIBS        => '-lgrpc',
+        header      => 'grpc/grpc.h',
+    );
 }
 
+# sanity check
+check_lib_or_exit(
+    %CHECKLIB_ARGS,
+    function    => 'grpc_version_string();',
+);
+
 WriteMakefile(
-      NAME          => 'Grpc::XS',
-      VERSION_FROM  => 'lib/Grpc/XS.pm',
-      AUTHOR        => 'Vincent van Dam',
-      LIBS          => ["$EXTRA_LDFLAGS -lgrpc"],
-      DEFINE        => '',
-      INC           => "$EXTRA_CPPFLAGS -I.",
-      C             => [ "Grpc.c", "util.c" ],
-      OBJECT        => '$(O_FILES)',
-      OPTIMIZE      => $DEBUG ? '-g' : '-O2',
+      NAME                  => 'Grpc::XS',
+      VERSION_FROM          => 'lib/Grpc/XS.pm',
+      AUTHOR                => 'Vincent van Dam',
+      LIBS                  => ["$EXTRA_LDFLAGS -lgrpc"],
+      DEFINE                => $EXTRA_DEFINES,
+      INC                   => "$EXTRA_INCFLAGS -I.",
+      C                     => [ "Grpc.c", "util.c" ],
+      OBJECT                => '$(O_FILES)',
+      OPTIMIZE              => $DEBUG ? '-g' : '-O2',
+      CONFIGURE_REQUIRES    => {
+          'Devel::CheckLib'     => 0,
+      },
     );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,6 +36,13 @@ check_lib_or_exit(
     function    => 'grpc_version_string();',
 );
 
+check_lib(
+    %CHECKLIB_ARGS,
+    function    => <<'EOT',
+grpc_op op; op.data.send_message.send_message = (grpc_byte_buffer *) NULL;
+EOT
+) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_2");
+
 WriteMakefile(
       NAME                  => 'Grpc::XS',
       VERSION_FROM          => 'lib/Grpc/XS.pm',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,16 +1,29 @@
 use 5.008005;
 use ExtUtils::MakeMaker;
 
+use Getopt::Long;
+
 # perl Makefile.PL -d to enable -g flag for gdb.
-my $DEBUG = grep $_ eq '-d', @ARGV;
+Getopt::Long::Configure('pass_through');
+GetOptions(
+    'd'             => \my $DEBUG,
+    'grpc-prefix=s' => \my $GRPC_PREFIX,
+)
+    or die "Error in command line arguments\n";
+
+my ($EXTRA_CPPFLAGS, $EXTRA_LDFLAGS);
+if ($GRPC_PREFIX) {
+    $EXTRA_CPPFLAGS = "-I$GRPC_PREFIX/include";
+    $EXTRA_LDFLAGS = "-L$GRPC_PREFIX/lib";
+}
 
 WriteMakefile(
       NAME          => 'Grpc::XS',
       VERSION_FROM  => 'lib/Grpc/XS.pm',
       AUTHOR        => 'Vincent van Dam',
-      LIBS          => ['-L/usr/local/lib -lgrpc'],
+      LIBS          => ["$EXTRA_LDFLAGS -lgrpc"],
       DEFINE        => '',
-      INC           => '-I.',
+      INC           => "$EXTRA_CPPFLAGS -I.",
       C             => [ "Grpc.c", "util.c" ],
       OBJECT        => '$(O_FILES)',
       OPTIMIZE      => $DEBUG ? '-g' : '-O2',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -52,6 +52,13 @@ grpc_slice_to_c_string(details.method);
 EOT
 ) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_2");
 
+check_lib(
+    %CHECKLIB_ARGS,
+    function    => <<'EOT',
+void (*call_unref)(grpc_call *call) = &grpc_call_unref;
+EOT
+) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_4");
+
 WriteMakefile(
       NAME                  => 'Grpc::XS',
       VERSION_FROM          => 'lib/Grpc/XS.pm',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -41,6 +41,15 @@ check_lib(
     function    => <<'EOT',
 grpc_op op; op.data.send_message.send_message = (grpc_byte_buffer *) NULL;
 EOT
+) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_1");
+
+check_lib(
+    %CHECKLIB_ARGS,
+    function    => <<'EOT',
+grpc_call_details details;
+grpc_call_details_init(&details);
+grpc_slice_to_c_string(details.method);
+EOT
 ) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_2");
 
 WriteMakefile(

--- a/ext/call.xs
+++ b/ext/call.xs
@@ -126,7 +126,11 @@ startBatch(Grpc::XS::Call self, ...)
             goto cleanup;
           }
           message_str = SvPV(*message_sv,message_len);
+#if !defined(GRPC_VERSION_1_1)
           ops[op_num].data.send_message =
+#else
+          ops[op_num].data.send_message.send_message =
+#endif
                       string_to_byte_buffer(message_str,message_len);
           break;
         case GRPC_OP_SEND_CLOSE_FROM_CLIENT:
@@ -181,10 +185,20 @@ startBatch(Grpc::XS::Call self, ...)
           }
           break;
         case GRPC_OP_RECV_INITIAL_METADATA:
-          ops[op_num].data.recv_initial_metadata = &recv_metadata;
+#if !defined(GRPC_VERSION_1_1)
+          ops[op_num].data.recv_initial_metadata =
+#else
+          ops[op_num].data.recv_initial_metadata.recv_initial_metadata =
+#endif
+              &recv_metadata;
           break;
         case GRPC_OP_RECV_MESSAGE:
-          ops[op_num].data.recv_message = &message;
+#if !defined(GRPC_VERSION_1_1)
+          ops[op_num].data.recv_message =
+#else
+          ops[op_num].data.recv_message.recv_message =
+#endif
+              &message;
           break;
         case GRPC_OP_RECV_STATUS_ON_CLIENT:
           ops[op_num].data.recv_status_on_client.trailing_metadata =
@@ -273,7 +287,11 @@ startBatch(Grpc::XS::Call self, ...)
 
     for (i = 0; i < op_num; i++) {
       if (ops[i].op == GRPC_OP_SEND_MESSAGE) {
+#if !defined(GRPC_VERSION_1_1)
         grpc_byte_buffer_destroy(ops[i].data.send_message);
+#else
+        grpc_byte_buffer_destroy(ops[i].data.send_message.send_message);
+#endif
       }
       if (ops[i].op == GRPC_OP_RECV_MESSAGE) {
         grpc_byte_buffer_destroy(message);

--- a/ext/call.xs
+++ b/ext/call.xs
@@ -363,6 +363,10 @@ void
 DESTROY(Grpc::XS::Call self)
   CODE:
     if (self->wrapped != NULL) {
+#if defined(GRPC_VERSION_1_4)
+      grpc_call_unref(self->wrapped);
+#else
       grpc_call_destroy(self->wrapped);
+#endif
     }
     Safefree(self);

--- a/ext/call.xs
+++ b/ext/call.xs
@@ -15,7 +15,21 @@ new(const char *class,  Grpc::XS::Channel channel,  \
     if ( items > 5 ) {
       croak("Too many variables for constructor Grpc::XS::Call");
     }
+#if defined(GRPC_VERSION_1_2)
+    grpc_slice host_override;
+    if ( items == 5) {
+      host_override = grpc_slice_from_sv(ST(4));
+    } else {
+      host_override = grpc_empty_slice();
+    }
 
+    grpc_slice method_slice = grpc_slice_from_static_string(method);
+    ctx->wrapped = grpc_channel_create_call(
+              channel->wrapped, NULL, GRPC_PROPAGATE_DEFAULTS, completion_queue,
+              method_slice, &host_override, deadline->wrapped, NULL);
+    grpc_slice_unref(host_override);
+    grpc_slice_unref(method_slice);
+#else
     const char* host_override = NULL;
     if ( items == 5) {
       host_override = SvPV_nolen(ST(4));
@@ -24,6 +38,7 @@ new(const char *class,  Grpc::XS::Channel channel,  \
     ctx->wrapped = grpc_channel_create_call(
               channel->wrapped, NULL, GRPC_PROPAGATE_DEFAULTS, completion_queue,
               method, host_override, deadline->wrapped, NULL);
+#endif
 
     RETVAL = ctx;
   OUTPUT: RETVAL
@@ -42,9 +57,13 @@ startBatch(Grpc::XS::Call self, ...)
     */
 
     HV *result = newHV();
-
+#if defined(GRPC_VERSION_1_2)
+    grpc_slice send_status_details = grpc_empty_slice();
+    grpc_slice recv_status_details = grpc_empty_slice();
+#else
     char *status_details = NULL;
-
+    size_t status_details_capacity = 0;
+#endif
     grpc_op ops[8];
 
     size_t op_num = 0;
@@ -52,7 +71,6 @@ startBatch(Grpc::XS::Call self, ...)
     grpc_byte_buffer *message;
     grpc_status_code status;
     grpc_call_error error;
-    size_t status_details_capacity = 0;
     int cancelled;
 
     char *message_str;
@@ -177,8 +195,14 @@ startBatch(Grpc::XS::Call self, ...)
               croak("Status details must be a string");
               goto cleanup;
             }
+#if defined(GRPC_VERSION_1_2)
+            send_status_details = grpc_slice_from_sv(*inner_value);
+            ops[op_num].data.send_status_from_server.status_details =
+                &send_status_details;
+#else
             ops[op_num].data.send_status_from_server.status_details =
                 SvPV_nolen(*inner_value);
+#endif
           } else {
             croak("String status details is required");
             goto cleanup;
@@ -204,10 +228,15 @@ startBatch(Grpc::XS::Call self, ...)
           ops[op_num].data.recv_status_on_client.trailing_metadata =
               &recv_trailing_metadata;
           ops[op_num].data.recv_status_on_client.status = &status;
+#if defined(GRPC_VERSION_1_2)
+          ops[op_num].data.recv_status_on_client.status_details =
+              &recv_status_details;
+#else
           ops[op_num].data.recv_status_on_client.status_details =
               &status_details;
           ops[op_num].data.recv_status_on_client.status_details_capacity =
               &status_details_capacity;
+#endif
           break;
         case GRPC_OP_RECV_CLOSE_ON_SERVER:
           ops[op_num].data.recv_close_on_server.cancelled = &cancelled;
@@ -264,8 +293,13 @@ startBatch(Grpc::XS::Call self, ...)
           hv_store(recv_status,"metadata",strlen("metadata"),
               newRV_noinc((SV *)grpc_parse_metadata_array(&recv_trailing_metadata)),0);
           hv_store(recv_status,"code",strlen("code"),newSViv(status),0);
+#if defined(GRPC_VERSION_1_2)
+          hv_store(recv_status, "details", strlen("details"),
+                        grpc_slice_to_sv(recv_status_details), 0);
+#else
           hv_store(recv_status, "details", strlen("details"),
                         newSVpv(status_details,strlen(status_details)), 0);
+#endif
           hv_store(result,"status",strlen("status"),newRV_noinc((SV *)recv_status),0);
           break;
         case GRPC_OP_RECV_CLOSE_ON_SERVER:
@@ -281,9 +315,14 @@ startBatch(Grpc::XS::Call self, ...)
     grpc_metadata_array_destroy(&trailing_metadata);
     grpc_metadata_array_destroy(&recv_metadata);
     grpc_metadata_array_destroy(&recv_trailing_metadata);
+#if defined(GRPC_VERSION_1_2)
+    grpc_slice_unref(recv_status_details);
+    grpc_slice_unref(send_status_details);
+#else
     if (status_details != NULL) {
       gpr_free(status_details);
     }
+#endif
 
     for (i = 0; i < op_num; i++) {
       if (ops[i].op == GRPC_OP_SEND_MESSAGE) {

--- a/ext/server.xs
+++ b/ext/server.xs
@@ -72,8 +72,8 @@ requestCall(Grpc::XS::Server self)
     SV* timeval_sv = sv_setref_pv(newSV (0), "Grpc::XS::Timeval", (void*)timeval_ctx);
     hv_store(result,"absolute_deadline",strlen("absolute_deadline"), timeval_sv, 0);
 
-    hv_store(result,"method",strlen("method"),newSVpv(details.method,strlen(details.method)),0);
-    hv_store(result,"host",strlen("host"),newSVpv(details.host,strlen(details.host)),0);
+    hv_store(result,"method",strlen("method"),grpc_slice_or_string_to_sv(details.method),0);
+    hv_store(result,"host",strlen("host"),grpc_slice_or_string_to_sv(details.host),0);
 
     hv_store(result,"metadata",strlen("metadata"),
                 newRV((SV*)grpc_parse_metadata_array(&metadata)),0);

--- a/t/01-call_credentials.t
+++ b/t/01-call_credentials.t
@@ -10,6 +10,8 @@ my $path = File::Basename::dirname( File::Spec->rel2abs(__FILE__) );
 
 plan tests => 28;
 
+delete @ENV{grep /https?_proxy/i, keys %ENV};
+
 use_ok("Grpc::XS::CallCredentials");
 
 ## ----------------------------------------------------------------------------

--- a/t/02-call.t
+++ b/t/02-call.t
@@ -9,6 +9,8 @@ plan tests => 15;
 #cancel
 #setCredentials
 
+delete @ENV{grep /https?_proxy/i, keys %ENV};
+
 use_ok("Grpc::XS::Call");
 use_ok("Grpc::XS::Channel");
 use_ok("Grpc::XS::Timeval");

--- a/t/15-xs_end_to_end.t
+++ b/t/15-xs_end_to_end.t
@@ -12,6 +12,8 @@ plan tests => 82;
 
 ## ----------------------------------------------------------------------------
 
+delete @ENV{grep /https?_proxy/i, keys %ENV};
+
 use_ok("Grpc::XS::Server");
 use_ok("Grpc::XS::Channel");
 use_ok("Grpc::XS::Call");

--- a/t/16-xs_secure_end_to_end.t
+++ b/t/16-xs_secure_end_to_end.t
@@ -14,6 +14,8 @@ use_ok("Grpc::XS::CallCredentials");
 
 ## ----------------------------------------------------------------------------
 
+delete @ENV{grep /https?_proxy/i, keys %ENV};
+
 use_ok("Grpc::XS::Server");
 use_ok("Grpc::XS::Channel");
 use_ok("Grpc::XS::Call");

--- a/util.c
+++ b/util.c
@@ -80,9 +80,11 @@ void perl_grpc_read_args_array(HV *hash, grpc_channel_args *args) {
     if (SvOK(value)) {
       args->args[args_index].key = key;
       if (SvIOK(value)) {
+        args->args[args_index].type = GRPC_ARG_INTEGER;
         args->args[args_index].value.integer = SvIV(value);
         args->args[args_index].value.string = NULL;
       } else {
+        args->args[args_index].type = GRPC_ARG_STRING;
         args->args[args_index].value.string = SvPV_nolen(value);
       }
     } else {

--- a/util.c
+++ b/util.c
@@ -9,7 +9,11 @@
 
 #include <grpc/grpc.h>
 #include <grpc/byte_buffer_reader.h>
+#if !defined(GRPC_VERSION_1_1)
 #include <grpc/support/slice.h>
+#else
+#include <grpc/slice.h>
+#endif
 #include <grpc/support/alloc.h>
 
 grpc_completion_queue *completion_queue;

--- a/util.h
+++ b/util.h
@@ -8,6 +8,9 @@
 
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
+#if defined(GRPC_VERSION_1_1)
+#include <grpc/slice.h>
+#endif
 
 grpc_byte_buffer *string_to_byte_buffer(char *string, size_t length);
 
@@ -32,5 +35,18 @@ void plugin_get_metadata(void *ptr, grpc_auth_metadata_context context,
                          void *user_data);
 
 void plugin_destroy_state(void *ptr);
+
+#if defined(GRPC_VERSION_1_2)
+SV *grpc_slice_to_sv(grpc_slice slice);
+grpc_slice grpc_slice_from_sv(SV *sv);
+#endif
+
+#if defined(GRPC_VERSION_1_2)
+#define grpc_slice_or_string_to_sv(slice) grpc_slice_to_sv((slice))
+#define grpc_slice_or_buffer_length_to_sv(slice) grpc_slice_to_sv((slice))
+#else
+#define grpc_slice_or_string_to_sv(string) newSVpvn((string), strlen(string))
+#define grpc_slice_or_buffer_length_to_sv(buffer) newSVpvn((buffer), (buffer##_length))
+#endif
 
 #endif


### PR DESCRIPTION
- Makefile.PL option to use a specifix libgrpc installation path
- use Devel::CheckLib to determine libgrpc version (I don't like this, but I did not find a better way)
- tested and fixed compilation for GRPC 1.1.4, 1.2.5, 1.3.9 and 1.4.2
- fix tests when http_proxy/https_proxy is set, because libgrpc ignores no_proxy