### PR TITLE
Perl 5.8 and strlen

### DIFF
--- a/ext/server.xs
+++ b/ext/server.xs
@@ -64,19 +64,19 @@ requestCall(Grpc::XS::Server self)
     CallCTX* call_ctx = (CallCTX *)malloc( sizeof(CallCTX) );
     call_ctx->wrapped = call;
     SV* call_sv = sv_setref_pv(newSV (0), "Grpc::XS::Call", (void*)call_ctx) ;
-    hv_store(result,"call",strlen("call"), call_sv, 0);
+    hv_stores(result,"call", call_sv);
 
     // add time object instance to hash
     TimevalCTX* timeval_ctx = (TimevalCTX *)malloc( sizeof(TimevalCTX) );
     timeval_ctx->wrapped = details.deadline;
     SV* timeval_sv = sv_setref_pv(newSV (0), "Grpc::XS::Timeval", (void*)timeval_ctx);
-    hv_store(result,"absolute_deadline",strlen("absolute_deadline"), timeval_sv, 0);
+    hv_stores(result,"absolute_deadline", timeval_sv);
 
-    hv_store(result,"method",strlen("method"),grpc_slice_or_string_to_sv(details.method),0);
-    hv_store(result,"host",strlen("host"),grpc_slice_or_string_to_sv(details.host),0);
+    hv_stores(result,"method",grpc_slice_or_string_to_sv(details.method));
+    hv_stores(result,"host",grpc_slice_or_string_to_sv(details.host));
 
-    hv_store(result,"metadata",strlen("metadata"),
-                newRV((SV*)grpc_parse_metadata_array(&metadata)),0);
+    hv_stores(result,"metadata",
+                newRV((SV*)grpc_parse_metadata_array(&metadata)));
 
   cleanup:
     grpc_call_details_destroy(&details);

--- a/util.c
+++ b/util.c
@@ -162,7 +162,7 @@ HV* grpc_parse_metadata_array(grpc_metadata_array *metadata_array) {
 }
 
 /* Populates a grpc_metadata_array with the data in a perl hash object.
-   Returns true on success and false on failure */
+   Returns TRUE on success and FALSE on failure */
 bool create_metadata_array(HV *hash, grpc_metadata_array *metadata) {
   // handle hashes
   if (SvTYPE(hash)!=SVt_PVHV) {
@@ -196,7 +196,7 @@ bool create_metadata_array(HV *hash, grpc_metadata_array *metadata) {
     metadata->metadata = gpr_malloc(metadata->capacity * sizeof(grpc_metadata));
   } else {
     metadata->metadata = NULL;
-    return true;
+    return TRUE;
   }
 
   metadata->count = 0;
@@ -226,12 +226,12 @@ bool create_metadata_array(HV *hash, grpc_metadata_array *metadata) {
         metadata->count += 1;
       } else {
         croak("args values must be int or string");
-        return false;
+        return FALSE;
       }
     }
   }
 
-  return true;
+  return TRUE;
 }
 
 /* Callback function for plugin creds API */

--- a/util.c
+++ b/util.c
@@ -244,10 +244,8 @@ void plugin_get_metadata(void *ptr, grpc_auth_metadata_context context,
   ENTER;
 
   HV* hash = newHV();
-  hv_store(hash,"service_url",strlen("service_url"),
-                            newSVpv(context.service_url,0),0);
-  hv_store(hash,"method_name",strlen("method_name"),
-                            newSVpv(context.method_name,0),0);
+  hv_stores(hash,"service_url", newSVpv(context.service_url,0));
+  hv_stores(hash,"method_name", newSVpv(context.method_name,0));
 
   SAVETMPS;
   PUSHMARK(sp);


### PR DESCRIPTION
Perl 5.8 compilation fixes (replace true/false with TRUE/FALSE).

Use hv_fetchs/hv_stores when storign/fetching a static string (for cleanliness).