### PR TITLE
Make wait() functions return status as a second return value

### DIFF
--- a/lib/Grpc/Client/ClientStreamingCall.pm
+++ b/lib/Grpc/Client/ClientStreamingCall.pm
@@ -43,7 +43,7 @@ sub write {
 
 ## Wait for the server to respond with data and a status.
 ##
-## @return [response data, status]
+## @return (response data, status)
 
 sub wait {
 	my $self  = shift;
@@ -59,7 +59,9 @@ sub wait {
 		$self->{_metadata} = $event->{metadata};
   }
 
-	return $self->deserializeResponse($event->{message},$event->{status});
+    return wantarray
+    ? ($self->deserializeResponse($event->{message}), $event->{status})
+    : $self->deserializeResponse($event->{message});
 }
 
 1;

--- a/lib/Grpc/Client/UnaryCall.pm
+++ b/lib/Grpc/Client/UnaryCall.pm
@@ -39,7 +39,7 @@ sub start {
 
 ## Wait for the server to respond with data and a status.
 ##
-## @return [response data, status]
+## @return (response data, status)
 
 sub wait {
 	my $self  = shift;
@@ -49,7 +49,9 @@ sub wait {
             Grpc::Constants::GRPC_OP_RECV_STATUS_ON_CLIENT() => true,
    	);
 
-	return $self->deserializeResponse($event->{message},$event->{status});
+    return wantarray
+    ? ($self->deserializeResponse($event->{message}), $event->{status})
+    : $self->deserializeResponse($event->{message});
 }
 
 1;


### PR DESCRIPTION
Hi,

$event->{status} passed to deserializeResponse() call is silently discarded, so there is no way to inspect status object sent by a server on unary and client streaming call.  Please review my fix.
https://github.com/joyrex2001/grpc-perl/blob/master/lib/Grpc/Client/UnaryCall.pm#L52
https://github.com/joyrex2001/grpc-perl/blob/master/lib/Grpc/Client/AbstractCall.pm#L102