### PR TITLE
Properly manage callback lifetime

### DIFF
--- a/ext/call_credentials.xs
+++ b/ext/call_credentials.xs
@@ -21,6 +21,7 @@ createFromPlugin(SV* callback)
     plugin.state = (void *)SvRV(callback);
     plugin.type = "";
     ctx->wrapped = grpc_metadata_credentials_create_from_plugin(plugin, NULL);
+    SvREFCNT_inc(callback);
     RETVAL = ctx;
   OUTPUT: RETVAL
 

--- a/util.c
+++ b/util.c
@@ -279,6 +279,7 @@ void plugin_get_metadata(void *ptr, grpc_auth_metadata_context context,
 /* Cleanup function for plugin creds API */
 void plugin_destroy_state(void *ptr) {
   SV *state = (SV *)ptr;
+  SvREFCNT_dec(state);
 }
 
 #if defined(GRPC_VERSION_1_2)


### PR DESCRIPTION
Otherwise it segfaults when an anonymous sub is used as a plugin callback.