### PR TITLE
Handle different versions of grpc_ssl_credentials_create()

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -62,6 +62,15 @@ exit(0);
 EOT
 ) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_4");
 
+check_lib(
+    %CHECKLIB_ARGS,
+    header => [$CHECKLIB_ARGS{header}, "grpc/grpc_security.h"],
+    function    => <<'EOT',
+return 0;
+grpc_ssl_credentials_create(0, 0, 0, 0);
+EOT
+) and ($EXTRA_DEFINES .= " -DGRPC_SSL_CREDENTIALS_HAS_4_ARGS");
+
 WriteMakefile(
       NAME                  => 'Grpc::XS',
       VERSION_FROM          => 'lib/Grpc/XS.pm',

--- a/ext/channel_credentials.xs
+++ b/ext/channel_credentials.xs
@@ -45,7 +45,11 @@ createSsl(const char *class, ...)
 
     ctx->wrapped = grpc_ssl_credentials_create(
         pem_root_certs,
-        pem_key_cert_pair.private_key == NULL ? NULL : &pem_key_cert_pair, NULL);
+        pem_key_cert_pair.private_key == NULL ? NULL : &pem_key_cert_pair, NULL
+#ifdef GRPC_SSL_CREDENTIALS_HAS_4_ARGS
+        , NULL
+#endif
+    );
 
     RETVAL = ctx;
   OUTPUT: RETVAL


### PR DESCRIPTION
In newer versions of grpc `grpc_ssl_credentials_create()` takes 4 arguments instead of 3.