### PR TITLE
Fix segfault on error

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -62,6 +62,15 @@ exit(0);
 EOT
 ) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_4");
 
+check_lib(
+    %CHECKLIB_ARGS,
+    function    => <<'EOT',
+return 0;
+grpc_op op;
+op.data.recv_status_on_client.error_string = 0;
+EOT
+) and ($EXTRA_DEFINES .= " -DGRPC_RECV_STATUS_ON_CLIENT_HAS_ERROR_STRING");
+
 WriteMakefile(
       NAME                  => 'Grpc::XS',
       VERSION_FROM          => 'lib/Grpc/XS.pm',

--- a/ext/call.xs
+++ b/ext/call.xs
@@ -222,6 +222,9 @@ startBatch(Grpc::XS::Call self, ...)
               &message;
           break;
         case GRPC_OP_RECV_STATUS_ON_CLIENT:
+#if defined GRPC_RECV_STATUS_ON_CLIENT_HAS_ERROR_STRING
+          ops[op_num].data.recv_status_on_client.error_string = NULL;
+#endif
           ops[op_num].data.recv_status_on_client.trailing_metadata =
               &recv_trailing_metadata;
           ops[op_num].data.recv_status_on_client.status = &status;


### PR DESCRIPTION
In newer versions of grpc a new field `error_string` was introduced
somewhere deep inside `grpc_op` structure. If it's not
initialized (i.e. has garbage), grpc can try to write to arbitrary
memory location. This error reporting can be disabled by setting
`error_string` to null.

Ideally, this should be used in a meaningful way instead - i.e. by
properly exposing this to perl side. But this is for later.