### PR TITLE
Remove bogus argument from createSsl() declaration

### DIFF
--- a/ext/channel_credentials.xs
+++ b/ext/channel_credentials.xs
@@ -8,7 +8,7 @@ createDefault()
   OUTPUT: RETVAL
 
 Grpc::XS::ChannelCredentials
-createSsl(const char *class, ...)
+createSsl(...)
   PREINIT:
     ChannelCredentialsCTX* ctx = (ChannelCredentialsCTX *)malloc( sizeof(ChannelCredentialsCTX) );
   CODE:


### PR DESCRIPTION
`createSsl()` should be called as a function, not a method - which can be immediately seen in `items % 2` assertion below. And this is already true for other methods in this file.