### PR TITLE
Fix grpc_slice -> perl scalar conversion

### DIFF
--- a/util.c
+++ b/util.c
@@ -285,8 +285,8 @@ void plugin_destroy_state(void *ptr) {
 #if defined(GRPC_VERSION_1_2)
 SV *grpc_slice_to_sv(grpc_slice slice) {
   char *slice_str = grpc_slice_to_c_string(slice);
-  SV *sv = newSVpv(slice_str, 0);
-  free(slice_str);
+  SV *sv = newSVpv(slice_str, GRPC_SLICE_LENGTH(slice));
+  gpr_free(slice_str);
   return sv;
 }
 


### PR DESCRIPTION
Values were being truncated at the first `\0` character.

Also `grpc_slice_to_c_string` doc says that `gpr_free` should be used for cleanup