### PR TITLE
Add minimal fork()-compatibilty

### DIFF
--- a/Grpc.xs
+++ b/Grpc.xs
@@ -17,14 +17,17 @@
 MODULE = Grpc::XS    PACKAGE = Grpc::XS
 
 BOOT:
-  grpc_init();
-  grpc_perl_init_completion_queue();
+  grpc_perl_init();
+
+void
+init()
+  CODE:
+    grpc_perl_init();
 
 void
 destroy()
   CODE:
-    grpc_perl_shutdown_completion_queue();
-    grpc_shutdown();
+    grpc_perl_destroy();
 
 MODULE = Grpc::XS    PACKAGE = Grpc::XS::Call
 INCLUDE: ext/call.xs

--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ directly. Instead it should be used in combination with a protocol buffer
 implementation that support service rpc definitions. Currently the excellent
 [Google::ProtocolBuffers::Dynamic](http://search.cpan.org/dist/Google-ProtocolBuffers-Dynamic/)
 module is the best option for this.
+
+## `fork()` compatibility
+
+It's possible to fork processes which use `Grpc::XS`, but only if this
+library is used exclusively inside child processes. This requires an
+explicit (de)initialization, otherwise things will hang forever on
+very first attemp to use anything grpc-related. Here is how it can be
+done:
+
+```perl
+Gprc::XS::destroy();
+if (fork() == 0) { # in child
+	Grpc::XS::init();
+	# Grpc::XS can be used in this child without any problems
+}
+```

--- a/t/17-fork_friendliness.t
+++ b/t/17-fork_friendliness.t
@@ -1,0 +1,30 @@
+#!perl -w
+use strict;
+use Data::Dumper;
+use Test::More;
+use Devel::Peek;
+
+use Grpc::XS::Server;
+use Grpc::XS::Channel;
+use Grpc::XS::Call;
+
+sub run_in_child {
+    Grpc::XS::init();
+    my $server = new Grpc::XS::Server();
+    my $port = $server->addHttp2Port('0.0.0.0:0');
+    my $channel = new Grpc::XS::Channel('localhost:'.$port);
+    $server->start();
+    exit 3;
+}
+
+Grpc::XS::destroy();
+my $pid1 = fork() || run_in_child();
+my $pid2 = fork() || run_in_child();
+
+waitpid $pid1, 0;
+is $?, 256 * 3;
+
+waitpid $pid2, 0;
+is $?, 256 * 3;
+
+done_testing;

--- a/util.h
+++ b/util.h
@@ -17,6 +17,9 @@ grpc_byte_buffer *string_to_byte_buffer(char *string, size_t length);
 void byte_buffer_to_string(grpc_byte_buffer *buffer, char **out_string,
                            size_t *out_length);
 
+void grpc_perl_init();
+void grpc_perl_destroy();
+
 /* The global completion queue for all operations */
 extern grpc_completion_queue *completion_queue;
 


### PR DESCRIPTION
Otherwise any attempt to use grpc in forked process blocks
indefinitely. There were a bunch of commits related to `fork()`
support in grpc library (related to Python bindings), but I was not
able to trigger the behaviour mentioned here where everything should
be closed automatically by itself.

So instead I took this approach, at least it makes `fork()`-ing possible.