### PR TITLE
add read() method for server streaming call

### DIFF
--- a/lib/Grpc/Client/ServerStreamingCall.pm
+++ b/lib/Grpc/Client/ServerStreamingCall.pm
@@ -36,6 +36,20 @@ sub start {
 	$self->{_metadata} = $event->{metadata};
 }
 
+## Reads the next value from the server.
+##
+## @return The next value from the server, or undef if there is none
+
+sub read {
+    my $self = shift;
+
+    my $response = $self->{_call}->startBatch(
+        Grpc::Constants::GRPC_OP_RECV_MESSAGE() => true,
+    )->{message};
+
+    return $self->deserializeResponse($response);
+}
+
 ## @return An array of response values
 
 sub responses {


### PR DESCRIPTION
Sometimes it might be convenient not to receive all messages at once from server stream. For instance when server sends to the stream large amount of data. So I've added read() method for server streaming call so that client could read separate messages. Please review.