### PR TITLE
Makefile.PL: Do not call undeclared C exit function

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,14 +33,13 @@ if ($GRPC_PREFIX) {
 # sanity check
 check_lib_or_exit(
     %CHECKLIB_ARGS,
-    function    => 'grpc_version_string();exit(0);',
+    function    => 'grpc_version_string();',
 );
 
 check_lib(
     %CHECKLIB_ARGS,
     function    => <<'EOT',
 grpc_op op; op.data.send_message.send_message = (grpc_byte_buffer *) NULL;
-exit(0);
 EOT
 ) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_1");
 
@@ -50,7 +49,6 @@ check_lib(
 grpc_call_details details;
 grpc_call_details_init(&details);
 grpc_slice_to_c_string(details.method);
-exit(0);
 EOT
 ) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_2");
 
@@ -58,7 +56,6 @@ check_lib(
     %CHECKLIB_ARGS,
     function    => <<'EOT',
 void (*call_unref)(grpc_call *call) = &grpc_call_unref;
-exit(0);
 EOT
 ) and ($EXTRA_DEFINES .= " -DGRPC_VERSION_1_4");
 


### PR DESCRIPTION
C99 and later language standards do not support implicit function declarations.  Future compilers will like reject them by default, causing these probes to fail.  Returning from main results in a zero exit status, so the call to exit is not necessary.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC