### PR TITLE
Use blocking shutdown call to prevent race if fork is used

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -112,6 +112,18 @@ return 0;
 EOT
 ) and ($EXTRA_DEFINES .= " -DGRPC_NO_INSECURE_BUILD");
 
+# grpc_shutdown() is async in recent versions of the library, leading
+# to a race at shutdown which can cause fork to fail. See
+# https://github.com/joyrex2001/grpc-perl/issues/22.
+# If the library has grpc_shutdown_blocking(), use that.
+check_lib(
+    %CHECKLIB_ARGS,
+    function    => <<'EOT',
+void *p = grpc_shutdown_blocking;
+return 0;
+EOT
+) and ($EXTRA_DEFINES .= " -DGRPC_HAS_SHUTDOWN_BLOCKING");
+
 
 WriteMakefile(
       NAME                  => 'Grpc::XS',

--- a/util.c
+++ b/util.c
@@ -63,7 +63,11 @@ void grpc_perl_destroy() {
     return;
   }
   grpc_perl_shutdown_completion_queue();
+#if defined(GRPC_HAS_SHUTDOWN_BLOCKING)
+  grpc_shutdown_blocking();
+#else
   grpc_shutdown();
+#endif
   module_initialized = false;
 }
 


### PR DESCRIPTION
Replace the call to `grpc_shutdown()` with a call to `grpc_shutdown_blocking()` when the gRPC library implements it (versions >= 1.20). This keeps `Grpc::XS::destroy()` synchronous, allowing it to be safely called before fork.

Fixes #22.

Update test `17_fork_friendliness.t` to further exercise init, destroy, and fork and optionally repeat the test in a loop (to catch races).