### PR TITLE
Fix dereferencing hashes in Grpc::XS::Call->startBatch()

### DIFF
--- a/ext/call.xs
+++ b/ext/call.xs
@@ -104,7 +104,7 @@ startBatch(Grpc::XS::Call self, ...)
 
       switch(atoi(SvPV_nolen(key))) {
         case GRPC_OP_SEND_INITIAL_METADATA:
-          value = SvRV(value);
+          if (SvROK(value)) value = SvRV(value);
           if (SvTYPE(value)!=SVt_PVHV) {
             croak("Expected a hash for GRPC_OP_SEND_INITIAL_METADATA");
             goto cleanup;
@@ -120,7 +120,7 @@ startBatch(Grpc::XS::Call self, ...)
                metadata.metadata;
           break;
         case GRPC_OP_SEND_MESSAGE:
-          value = SvRV(value);
+          if (SvROK(value)) value = SvRV(value);
           if (SvTYPE(value)!=SVt_PVHV) {
             croak("Expected a hash for send message");
             goto cleanup;
@@ -165,7 +165,8 @@ startBatch(Grpc::XS::Call self, ...)
           if (hv_exists((HV*)value, "metadata", strlen("metadata"))) {
             SV** inner_value;
             inner_value = hv_fetchs((HV*)value, "metadata", 0);
-            if (!create_metadata_array((HV*)SvRV(*inner_value), &trailing_metadata)) {
+            if (!SvROK(*inner_value) ||
+                !create_metadata_array((HV*)SvRV(*inner_value), &trailing_metadata)) {
               croak("Bad trailing metadata value given");
               goto cleanup;
             }


### PR DESCRIPTION
Running t/15-xs_end_to_end.t under valgrind revealed reading unitialized memory:

    $ valgrind -- perl -Iblib/{lib,arch} t/15-xs_end_to_end.t
    ok 44 - status->details does not contain status:client_server_full_response_text
    ==17367== Conditional jump or move depends on uninitialised value(s)
    ==17367==    at 0x6ABC869: XS_Grpc__XS__Call_startBatch (call.xs:124)
    ==17367==    by 0x4B42880: Perl_rpp_invoke_xs (inline.h:1176)
    ==17367==    by 0x4B42880: Perl_pp_entersub (pp_hot.c:6558)
    ==17367==    by 0x4BD223F: Perl_runops_standard (run.c:41)
    ==17367==    by 0x4A91F46: S_run_body (perl.c:2884)
    ==17367==    by 0x4A91F46: perl_run (perl.c:2799)
    ==17367==    by 0x400135D: main (perlmain.c:127)
    ==17367==
    ok 45 - failed to trigger exception/testInvalidClientMessageArray
    [...]
    ok 50 - event->method has wrong value
    ==17367== Conditional jump or move depends on uninitialised value(s)
    ==17367==    at 0x6ABC1D4: create_metadata_array (util.c:200)
    ==17367==    by 0x6ABCA71: XS_Grpc__XS__Call_startBatch (call.xs:168)
    ==17367==    by 0x4B42880: Perl_rpp_invoke_xs (inline.h:1176)
    ==17367==    by 0x4B42880: Perl_pp_entersub (pp_hot.c:6558)
    ==17367==    by 0x4BD223F: Perl_runops_standard (run.c:41)
    ==17367==    by 0x4A91BA1: S_run_body (perl.c:2879)
    ==17367==    by 0x4A91BA1: perl_run (perl.c:2799)
    ==17367==    by 0x400135D: main (perlmain.c:127)
    ==17367==
    Expected hash for create_metadata_array() args at t/15-xs_end_to_end.t line 298.
    ok 51 - failed to trigger exception/testInvalidServerStatusMetadata
    [...]

The cause was an unconditional dereference followed by a type check:

        case GRPC_OP_SEND_MESSAGE:
          value = SvRV(value);
→         if (SvTYPE(value)!=SVt_PVHV) {
            croak("Expected a hash for send message");
            goto cleanup;
          }

This bug was triggered by the test intentionally passing a string instead of a reference to a hash:

      $event = $call->startBatch(
	  Grpc::Constants::GRPC_OP_SEND_INITIAL_METADATA() => {},
	  Grpc::Constants::GRPC_OP_SEND_CLOSE_FROM_CLIENT() => 1,
→	  Grpc::Constants::GRPC_OP_SEND_MESSAGE() => 'invalid',
      );

This patch performs the dereference only if the subroutine argument is a reference. The same way was already used for
GRPC_OP_SEND_STATUS_FROM_SERVER key type.